### PR TITLE
feat: column color system v1

### DIFF
--- a/column_letters.py
+++ b/column_letters.py
@@ -1,0 +1,28 @@
+def index_to_column_letters(index: int) -> str:
+    """Convert a 0-based column index to Excel-style letters (A, B, ..., Z, AA, AB, ...).
+
+    Args:
+        index: Zero-based column index (0 => 'A').
+
+    Returns:
+        The Excel-style column label as a string.
+
+    Raises:
+        ValueError: If index is negative.
+    """
+    if not isinstance(index, int):
+        raise TypeError("index must be an int")
+    if index < 0:
+        raise ValueError("index must be non-negative")
+
+    # Excel-like base-26 with no zero digit: 0->A, 25->Z, 26->AA
+    result = []
+    n = index
+    while True:
+        n, rem = divmod(n, 26)
+        result.append(chr(ord('A') + rem))
+        if n == 0:
+            break
+        n -= 1  # Carry handling due to lack of zero digit in Excel columns
+    return ''.join(reversed(result))
+

--- a/config.json
+++ b/config.json
@@ -13,6 +13,17 @@
         "workspace_files": [
             "F:\\ProjectsNew\\Diablo2TextEditor\\CubeMainWorking.txt",
             "F:\\ProjectsNew\\Diablo2TextEditor\\CubeMainNotWorking.txt"
-        ]
+        ],
+        "enable_column_colors": true,
+        "column_color_overrides": {
+            "ladder": {
+                "bg": "#FFE0B2",
+                "fg": "#000000"
+            }
+        },
+        "custom_column_color_palette": [],
+        "show_column_letters_enabled": true,
+        "header_min_section_size": 130,
+        "high_contrast_column_text_enabled": true
     }
 }

--- a/config_manager.py
+++ b/config_manager.py
@@ -28,6 +28,10 @@ class ConfigManager:
         settings.setdefault("crosshair_enabled", True)
         settings.setdefault("crosshair_thickness", 1)
         settings.setdefault("crosshair_hover_enabled", True)
+        # Column color feature configuration
+        settings.setdefault("enable_column_colors", True)
+        settings.setdefault("column_color_overrides", {})
+        settings.setdefault("custom_column_color_palette", [])
         # Add the new setting for freezing the first row
         #settings.setdefault("freeze_first_row_enabled", False)
         config["settings"] = settings

--- a/tests/test_column_letters.py
+++ b/tests/test_column_letters.py
@@ -1,0 +1,29 @@
+import pytest
+
+from column_letters import index_to_column_letters
+
+
+@pytest.mark.parametrize(
+    "idx,expected",
+    [
+        (0, "A"),
+        (1, "B"),
+        (25, "Z"),
+        (26, "AA"),
+        (27, "AB"),
+        (51, "AZ"),
+        (52, "BA"),
+        (701, "ZZ"),
+        (702, "AAA"),
+    ],
+)
+def test_index_to_column_letters(idx, expected):
+    assert index_to_column_letters(idx) == expected
+
+
+def test_index_to_column_letters_errors():
+    with pytest.raises(ValueError):
+        index_to_column_letters(-1)
+    with pytest.raises(TypeError):
+        index_to_column_letters(3.14)  # type: ignore[arg-type]
+


### PR DESCRIPTION
- Make header labels readable over colored headers by repainting text on top with high-contrast color and badge-aware layout
- Add per-column text (foreground) color overrides with context menu controls (black/white/custom/auto)
- Add global setting: High-contrast text on colored columns; applies to headers and cells when no explicit text color is set
- Add Settings option: Header minimum width (px); apply on Save and on startup
- Fix workspace crash: ensure workspace item loads via _open_in_tab so self.tableView is valid before rendering
- Config: persist new settings (high_contrast_column_text_enabled, header_min_section_size) and column text color overrides (fg)

Also includes minor refactors and safeguards in painting paths.